### PR TITLE
[Draft] Update darwin-build to support x86_64

### DIFF
--- a/bin/darwin-build
+++ b/bin/darwin-build
@@ -26,7 +26,7 @@ echo "${GREEN}Requesting sudo to set homebrew tap permissions in $(BREW_PREFIX)/
 
 # This is reset by nix-homebrew, we need write permission to this dir to manage homebrew taps
 sudo mkdir -p $BREW_PREFIX/Library/Taps/homebrew/
-sudo /bin/chmod +a "atm allow list,add_file,search,delete,add_subdirectory,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown" $BREW_PREFIX/Library/Taps/homebrew/
+sudo /bin/chmod +a "dustin allow list,add_file,search,delete,add_subdirectory,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown" $BREW_PREFIX/Library/Taps/homebrew/
 
 echo "${GREEN}Starting build...${CLEAR}"
 

--- a/bin/darwin-build
+++ b/bin/darwin-build
@@ -15,14 +15,14 @@ export NIXPKGS_ALLOW_UNFREE=1
 cd $(dirname $(readlink -f $0))
 cd ..
 
-echo "${GREEN}Requesting sudo to set homebrew tap permissions...${CLEAR}"
-
 ARCH=$(uname -m)
 if [ $ARCH == "x86_64" ]; then
   BREW_PREFIX=/usr/local/Homebrew
 elif [ $ARCH == "arm64" ]; then
   BREW_PREFIX=/opt/homebrew
 fi
+
+echo "${GREEN}Requesting sudo to set homebrew tap permissions in $(BREW_PREFIX)/Library/Taps/homebrew...${CLEAR}"
 
 # This is reset by nix-homebrew, we need write permission to this dir to manage homebrew taps
 sudo mkdir -p $BREW_PREFIX/Library/Taps/homebrew/

--- a/bin/darwin-build
+++ b/bin/darwin-build
@@ -17,9 +17,16 @@ cd ..
 
 echo "${GREEN}Requesting sudo to set homebrew tap permissions...${CLEAR}"
 
+ARCH=$(uname -m)
+if [ $ARCH == "x86_64" ]; then
+  BREW_PREFIX=/usr/local/Homebrew
+elif [ $ARCH == "arm64" ]; then
+  BREW_PREFIX=/opt/homebrew
+fi
+
 # This is reset by nix-homebrew, we need write permission to this dir to manage homebrew taps
-sudo mkdir -p /opt/homebrew/Library/Taps/homebrew/
-sudo /bin/chmod +a "dustin allow list,add_file,search,delete,add_subdirectory,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown" /opt/homebrew/Library/Taps/homebrew/
+sudo mkdir -p $BREW_PREFIX/Library/Taps/homebrew/
+sudo /bin/chmod +a "atm allow list,add_file,search,delete,add_subdirectory,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown" $BREW_PREFIX/Library/Taps/homebrew/
 
 echo "${GREEN}Starting build...${CLEAR}"
 


### PR DESCRIPTION
Homebrew root is different for x86_64 vs arm64. I have compared this between both architectures.

```
# On ARM
$ uname -m
arm64

# On x86_64
$ uname -m
x86_64
```