### PR TITLE
A few tweaks to get templates working on x86_64-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ mkdir -p nixos-config && cd nixos-config && nix flake --extra-experimental-featu
 
 ### 4. Make apps executable
 ```sh
-find apps/aarch64-darwin -type f \( -name apply -o -name build -o -name build-switch -o -name create-keys -o -name copy-keys -o -name check-keys \) -exec chmod +x {} \;
+find apps/$(uname -m)-darwin -type f \( -name apply -o -name build -o -name build-switch -o -name create-keys -o -name copy-keys -o -name check-keys \) -exec chmod +x {} \;
 ```
 
 ### 5. Apply your current user info

--- a/templates/starter-with-secrets/apps/x86_64-darwin/build
+++ b/templates/starter-with-secrets/apps/x86_64-darwin/build
@@ -5,7 +5,7 @@ YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m'
 
-FLAKE="Dustins-MBP"
+FLAKE="macos"
 SYSTEM="darwinConfigurations.$FLAKE.system"
 
 export NIXPKGS_ALLOW_UNFREE=1

--- a/templates/starter-with-secrets/flake.nix
+++ b/templates/starter-with-secrets/flake.nix
@@ -75,7 +75,7 @@
 
       darwinConfigurations = let user = "%USER%"; in {
         macos = darwin.lib.darwinSystem {
-          system = "aarch64-darwin";
+          system = "x86_64-darwin";
           specialArgs = inputs;
           modules = [
             home-manager.darwinModules.home-manager

--- a/templates/starter/apps/x86_64-darwin/build
+++ b/templates/starter/apps/x86_64-darwin/build
@@ -5,7 +5,7 @@ YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m'
 
-FLAKE="Dustins-MBP"
+FLAKE="macos"
 SYSTEM="darwinConfigurations.$FLAKE.system"
 
 export NIXPKGS_ALLOW_UNFREE=1

--- a/templates/starter/flake.nix
+++ b/templates/starter/flake.nix
@@ -73,7 +73,7 @@
 
       darwinConfigurations = let user = "%USER%"; in {
         macos = darwin.lib.darwinSystem {
-          system = "aarch64-darwin";
+          system = "x86_64-darwin";
           specialArgs = inputs;
           modules = [
             home-manager.darwinModules.home-manager


### PR DESCRIPTION
This update doesn't detect the system/platform automatically when applying the starter templates. I'm a nix noob, so I had to hard-code the switch from "aarch64-darwin" to "x86_64-darwin" in `templates/starter/flake.nix` and `templates/starter-with-secrets/flake.nix`.