### PR TITLE
Dustins-MBP=>macos in 'build-switch'

### DIFF
--- a/templates/starter-with-secrets/apps/x86_64-darwin/build-switch
+++ b/templates/starter-with-secrets/apps/x86_64-darwin/build-switch
@@ -5,7 +5,7 @@ YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m'
 
-FLAKE="Dustins-MBP"
+FLAKE="macos"
 SYSTEM="darwinConfigurations.$FLAKE.system"
 
 export NIXPKGS_ALLOW_UNFREE=1

--- a/templates/starter/apps/x86_64-darwin/build-switch
+++ b/templates/starter/apps/x86_64-darwin/build-switch
@@ -5,7 +5,7 @@ YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m'
 
-FLAKE="Dustins-MBP"
+FLAKE="macos"
 SYSTEM="darwinConfigurations.$FLAKE.system"
 
 export NIXPKGS_ALLOW_UNFREE=1


### PR DESCRIPTION
The "build-switch" config also needed to be updated from "Dustins-MBP" to the more generic "macos" name.

With this, I have managed to successfully configure my Intel-CPU MacBookPro, and I'm now working my way through setting up my applications, tools, secrets, as I like them.

Thanks!
Jeff