### PR TITLE
fix: starterWithSecrets -> starter-with-secrets

### DIFF
--- a/apps/x86_64-linux/install-with-secrets
+++ b/apps/x86_64-linux/install-with-secrets
@@ -17,7 +17,7 @@ cleanup() {
 download_config() {
   curl -LJ0 https://github.com/dustinlyons/nixos-config/archive/main.zip -o nixos-config-main.zip
   unzip nixos-config-main.zip
-  mv nixos-config-main/templates/starterWithSecrets nixos-config
+  mv nixos-config-main/templates/starter-with-secrets nixos-config
   cd nixos-config
 }
 


### PR DESCRIPTION
When using the install-with-secrets option for nixos the download_config function attempts to move a folder named 'starterWithSecrets' which cannot be found. This folder is now called starter-with-secrets. This updates the download_config function to move the correct folder.

Thanks for providing a great starting point!