### PR TITLE
Move extraConfig blocks for SSH config to use home-manager built in functions

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -88,7 +88,7 @@ let name = "Dustin Lyons";
     };
     extraConfig = {
       init.defaultBranch = "main";
-      core = { 
+      core = {
 	    editor = "vim";
         autocrlf = "input";
       };
@@ -267,17 +267,27 @@ let name = "Dustin Lyons";
 
   ssh = {
     enable = true;
-
-    extraConfig = lib.mkMerge [
+    includes = [
       (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
-        ''
-        Include /home/${user}/.ssh/config_external
-        '')
+        "/home/${user}/.ssh/config.d/*.ssh"
+      )
       (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        ''
-        Include /Users/${user}/.ssh/config_external
-        '')
-      ''
+        "/Users/${user}/.ssh/config.d/*.ssh"
+      )
+    ];
+    matchBlocks = {
+      "github.com" = {
+        identitiesOnly = true;
+        identityFile = [
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
+            "/home/${user}/.ssh/id_github"
+          )
+          (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
+            "/Users/${user}/.ssh/id_github"
+          )
+        ];
+      };
+    };
         Host github.com
           Hostname github.com
           IdentitiesOnly yes

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -288,19 +288,6 @@ let name = "Dustin Lyons";
         ];
       };
     };
-        Host github.com
-          Hostname github.com
-          IdentitiesOnly yes
-      ''
-      (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
-        ''
-          IdentityFile /home/${user}/.ssh/id_github
-        '')
-      (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        ''
-          IdentityFile /Users/${user}/.ssh/id_github
-        '')
-    ];
   };
 
   tmux = {

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -269,10 +269,10 @@ let name = "Dustin Lyons";
     enable = true;
     includes = [
       (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
-        "/home/${user}/.ssh/config.d/*.ssh"
+        "/home/${user}/.ssh/config_external"
       )
       (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        "/Users/${user}/.ssh/config.d/*.ssh"
+        "/Users/${user}/.ssh/config_external"
       )
     ];
     matchBlocks = {

--- a/templates/starter-with-secrets/modules/darwin/secrets.nix
+++ b/templates/starter-with-secrets/modules/darwin/secrets.nix
@@ -2,7 +2,7 @@
 
 let user = "%USER%"; in
 {
-  age.identityPaths = [ 
+  age.identityPaths = [
     "/Users/${user}/.ssh/id_ed25519"
   ];
 
@@ -13,7 +13,7 @@ let user = "%USER%"; in
   #       instead, you can reference the age files and specify the symlink path here. Then add your
   #       public key in shared/files.nix.
   #
-  #       If you change the key name, you'll need to update the SSH extraConfig in shared/home-manager.nix
+  #       If you change the key name, you'll need to update the SSH configuration in shared/home-manager.nix
   #       so Github reads it correctly.
 
   #

--- a/templates/starter-with-secrets/modules/nixos/secrets.nix
+++ b/templates/starter-with-secrets/modules/nixos/secrets.nix
@@ -13,7 +13,7 @@ let user = "%USER%"; in
   #       instead, you can reference the age files and specify the symlink path here. Then add your
   #       public key in shared/files.nix.
   #
-  #       If you change the key name, you'll need to update the SSH extraConfig in shared/home-manager.nix
+  #       If you change the key name, you'll need to update the SSH configuration in shared/home-manager.nix
   #       so Github reads it correctly.
 
   #

--- a/templates/starter-with-secrets/modules/shared/home-manager.nix
+++ b/templates/starter-with-secrets/modules/shared/home-manager.nix
@@ -74,7 +74,7 @@ let name = "%NAME%";
     };
     extraConfig = {
       init.defaultBranch = "main";
-      core = { 
+      core = {
 	    editor = "vim";
         autocrlf = "input";
       };
@@ -261,22 +261,27 @@ let name = "%NAME%";
 
   ssh = {
     enable = true;
-
-    extraConfig = lib.mkMerge [
-      ''
-        Host github.com
-          Hostname github.com
-          IdentitiesOnly yes
-      ''
+    includes = [
       (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
-        ''
-          IdentityFile /home/${user}/.ssh/id_github
-        '')
+        "/home/${user}/.ssh/config_external"
+      )
       (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        ''
-          IdentityFile /Users/${user}/.ssh/id_github
-        '')
+        "/Users/${user}/.ssh/config_external"
+      )
     ];
+    matchBlocks = {
+      "github.com" = {
+        identitiesOnly = true;
+        identityFile = [
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
+            "/home/${user}/.ssh/id_github"
+          )
+          (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
+            "/Users/${user}/.ssh/id_github"
+          )
+        ];
+      };
+    };
   };
 
   tmux = {

--- a/templates/starter/modules/shared/home-manager.nix
+++ b/templates/starter/modules/shared/home-manager.nix
@@ -67,7 +67,7 @@ let name = "%NAME%";
     };
     extraConfig = {
       init.defaultBranch = "main";
-      core = { 
+      core = {
 	    editor = "vim";
         autocrlf = "input";
       };
@@ -253,22 +253,27 @@ let name = "%NAME%";
 
   ssh = {
     enable = true;
-
-    extraConfig = lib.mkMerge [
-      ''
-        Host github.com
-          Hostname github.com
-          IdentitiesOnly yes
-      ''
+    includes = [
       (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
-        ''
-          IdentityFile /home/${user}/.ssh/id_github
-        '')
+        "/home/${user}/.ssh/config_external"
+      )
       (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        ''
-          IdentityFile /Users/${user}/.ssh/id_github
-        '')
+        "/Users/${user}/.ssh/config_external"
+      )
     ];
+    matchBlocks = {
+      "github.com" = {
+        identitiesOnly = true;
+        identityFile = [
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux
+            "/home/${user}/.ssh/id_github"
+          )
+          (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
+            "/Users/${user}/.ssh/id_github"
+          )
+        ];
+      };
+    };
   };
 
   tmux = {


### PR DESCRIPTION
This change uses the home-manager built-in functions to configure ssh_config, it also moves these statements above the 'general' configuration which makes sense for ssh_config as the first match in config is applied.