### PR TITLE
Fix `dl/download-default-config` error

### DIFF
--- a/modules/shared/config/emacs/init.el
+++ b/modules/shared/config/emacs/init.el
@@ -123,9 +123,10 @@
                         (lambda (_status)
                           ;; delete-region removes the HTTP headers from the downloaded content.
                           (delete-region (point-min) (1+ url-http-end-of-headers))
+                          ;; save the contents of the buffer to the file.
                           (write-file default-config-file)))
-        (message "Default configuration downloaded successfully."))
-    (error (message "Error occurred while downloading the default configuration.")))))
+          (message "Default configuration downloaded successfully.")))
+    (error (message "Error occurred while downloading the default configuration."))))
 
 ;; -------------------------
 ;; Load Org Config or Default

--- a/templates/starter-with-secrets/modules/shared/config/emacs/init.el
+++ b/templates/starter-with-secrets/modules/shared/config/emacs/init.el
@@ -123,9 +123,10 @@
                         (lambda (_status)
                           ;; delete-region removes the HTTP headers from the downloaded content.
                           (delete-region (point-min) (1+ url-http-end-of-headers))
+                          ;; save the contents of the buffer to the file.
                           (write-file default-config-file)))
-        (message "Default configuration downloaded successfully."))
-    (error (message "Error occurred while downloading the default configuration.")))))
+          (message "Default configuration downloaded successfully.")))
+    (error (message "Error occurred while downloading the default configuration."))))
 
 ;; -------------------------
 ;; Load Org Config or Default

--- a/templates/starter/modules/shared/config/emacs/init.el
+++ b/templates/starter/modules/shared/config/emacs/init.el
@@ -123,9 +123,10 @@
                         (lambda (_status)
                           ;; delete-region removes the HTTP headers from the downloaded content.
                           (delete-region (point-min) (1+ url-http-end-of-headers))
+                          ;; save the contents of the buffer to the file.
                           (write-file default-config-file)))
-        (message "Default configuration downloaded successfully."))
-    (error (message "Error occurred while downloading the default configuration.")))))
+          (message "Default configuration downloaded successfully.")))
+    (error (message "Error occurred while downloading the default configuration."))))
 
 ;; -------------------------
 ;; Load Org Config or Default


### PR DESCRIPTION
The final error message ("Error occurred while downloading...") is currently in the `progn`-block, causing the `dl/download-default-config` function to always error. This moves the error outside the `progn`-block and should fix the issue.