### PR TITLE
Fix org-roam straight branch (master -> main)

### DIFF
--- a/templates/starter-with-secrets/modules/shared/config/emacs/config.org
+++ b/templates/starter-with-secrets/modules/shared/config/emacs/config.org
@@ -694,7 +694,7 @@ These are templates used to create new notes.
   (require 'ucs-normalize)
   (use-package org-roam
     :straight (:host github :repo "org-roam/org-roam"
-               :branch "master"
+               :branch "main"
                :files (:defaults "extensions/*")
     :build (:not compile))
     :init

--- a/templates/starter/modules/shared/config/emacs/config.org
+++ b/templates/starter/modules/shared/config/emacs/config.org
@@ -694,7 +694,7 @@ These are templates used to create new notes.
   (require 'ucs-normalize)
   (use-package org-roam
     :straight (:host github :repo "org-roam/org-roam"
-               :branch "master"
+               :branch "main"
                :files (:defaults "extensions/*")
     :build (:not compile))
     :init


### PR DESCRIPTION
https://github.com/org-roam/org-roam/tree/master doesn't exist anymore. This changes the download to point to https://github.com/org-roam/org-roam/tree/main instead.