### PR TITLE
Remove deprecated fonts.fontDir.enable option from nix-darwin configuration

### DIFF
--- a/templates/starter-with-secrets/hosts/darwin/default.nix
+++ b/templates/starter-with-secrets/hosts/darwin/default.nix
@@ -42,9 +42,6 @@ let user = "%USER%"; in
     agenix.packages."${pkgs.system}".default
   ] ++ (import ../../modules/shared/packages.nix { inherit pkgs; });
 
-  # Enable fonts dir
-  fonts.fontDir.enable = true;
-
   launchd.user.agents.emacs.path = [ config.environment.systemPath ];
   launchd.user.agents.emacs.serviceConfig = {
     KeepAlive = true;

--- a/templates/starter/hosts/darwin/default.nix
+++ b/templates/starter/hosts/darwin/default.nix
@@ -39,9 +39,6 @@ let user = "%USER%"; in
     emacs-unstable
   ] ++ (import ../../modules/shared/packages.nix { inherit pkgs; });
 
-  # Enable fonts dir
-  fonts.fontDir.enable = true;
-
   launchd.user.agents.emacs.path = [ config.environment.systemPath ];
   launchd.user.agents.emacs.serviceConfig = {
     KeepAlive = true;


### PR DESCRIPTION
This configuration option was removed upstream in nix-darwin:

https://github.com/LnL7/nix-darwin/pull/754