### PR TITLE
Fix typo in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can search for packages on the [official NixOS website](https://search.nixos
 
 * [`modules/darwin/casks.nix`](https://github.com/dustinlyons/nixos-config/blob/main/modules/darwin/casks.nix)
 * [`modules/darwin/packages.nix`](https://github.com/dustinlyons/nixos-config/blob/main/modules/darwin/packages.nix)
-* [`modules/shared/packages/nix`](https://github.com/dustinlyons/nixos-config/blob/main/modules/shared/packages.nix)
+* [`modules/shared/packages.nix`](https://github.com/dustinlyons/nixos-config/blob/main/modules/shared/packages.nix)
 
 ### 7. Review your shell configuration
 Add anything from your existing `~/.zshrc`, or just review the new configuration.


### PR DESCRIPTION
Update file path from `modules/shared/packages/nix` to `modules/shared/packages.nix`