### PR TITLE
Fix Adwaita Icon Theme call

### DIFF
--- a/apps/x86_64-linux/install
+++ b/apps/x86_64-linux/install
@@ -15,7 +15,7 @@ cleanup() {
 }
 
 download_config() {
-  curl -LJ0 https://github.com/dustinlyons/nixos-config/archive/main.zip -o nixos-config-main.zip
+  curl -LJ0 https://github.com/jackdbai/nixos-config/archive/main.zip -o nixos-config-main.zip
   unzip nixos-config-main.zip
   mv nixos-config-main/templates/starter nixos-config
   cd nixos-config

--- a/apps/x86_64-linux/install
+++ b/apps/x86_64-linux/install
@@ -15,7 +15,7 @@ cleanup() {
 }
 
 download_config() {
-  curl -LJ0 https://github.com/jackdbai/nixos-config/archive/main.zip -o nixos-config-main.zip
+  curl -LJ0 https://github.com/dustinlyons/nixos-config/archive/main.zip -o nixos-config-main.zip
   unzip nixos-config-main.zip
   mv nixos-config-main/templates/starter nixos-config
   cd nixos-config

--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -46,11 +46,11 @@ in
     enable = true;
     iconTheme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
     theme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
   };
 

--- a/templates/starter-with-secrets/modules/nixos/home-manager.nix
+++ b/templates/starter-with-secrets/modules/nixos/home-manager.nix
@@ -41,11 +41,11 @@ in
     enable = true;
     iconTheme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
     theme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
   };
 

--- a/templates/starter/modules/nixos/home-manager.nix
+++ b/templates/starter/modules/nixos/home-manager.nix
@@ -41,11 +41,11 @@ in
     enable = true;
     iconTheme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
     theme = {
       name = "Adwaita-dark";
-      package = pkgs.gnome.adwaita-icon-theme;
+      package = pkgs.adwaita-icon-theme;
     };
   };
 


### PR DESCRIPTION
Currently installation exits with an error: 
```The `gnome.adwaita-icon-theme` was moved to top-level. Please use `pkgs.adwaita-icon-theme` directly.```

Removing `gnome.` from the calls in `home-manager.nix` has resolved it.