### PR TITLE
Fix: Build errors on Sequoia

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ After installation, open a new terminal session to make the `nix` executable ava
 
 > [!IMPORTANT]
 >
+> If planning to upgrade to Sequoia, [prepare Nix](https://determinate.systems/posts/nix-support-for-macos-sequoia/) before proceeding.
+>
 > If using [the official installation instructions](https://nixos.org/download) instead, [`flakes`](https://nixos.wiki/wiki/Flakes) and [`nix-command`](https://nixos.wiki/wiki/Nix_command) aren't available by default.
 >
 > You'll need to enable them.
@@ -278,6 +280,19 @@ nix run .#build
 > Please check there is nothing critical in these files, rename them by adding .before-nix-darwin to the end, and then try again.
 > ```
 > Backup and move the files out of the way and/or edit your Nix configuration before continuing.
+
+> [!WARNING]
+> You may encounter `error: Build user group has mismatching GID, aborting activation` if you have already upgraded to Sequoia and haven't had [prepared Nix](https://determinate.systems/posts/nix-support-for-macos-sequoia/) before it.
+> The error will list the files like this:
+> 
+> ```
+> error: Build user group has mismatching GID, aborting activation
+> The default Nix build user group ID was changed from 30000 to 350.
+> You are currently managing Nix build users with nix-darwin, but your
+> nixbld group has GID 350, whereas we expected 30000.
+> ```
+>
+> You will have to [unintsall Nix](https://zero-to-nix.com/start/uninstall/), and [intsall Nix](https://zero-to-nix.com/start/install/) again with `--nix-build-group-id 30000` flag.
 
 ### 10. Make changes
 Finally, alter your system with this command:

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ nix run .#build
 > Backup and move the files out of the way and/or edit your Nix configuration before continuing.
 
 > [!WARNING]
-> You may encounter `error: Build user group has mismatching GID, aborting activation` if you have already upgraded to Sequoia and haven't had [prepared Nix](https://determinate.systems/posts/nix-support-for-macos-sequoia/) before it.
+> You may encounter `error: Build user group has mismatching GID, aborting activation` if you have already upgraded to Sequoia but haven't had [prepared Nix](https://determinate.systems/posts/nix-support-for-macos-sequoia/) before that.
 > The error will list the files like this:
 > 
 > ```
@@ -292,7 +292,7 @@ nix run .#build
 > nixbld group has GID 350, whereas we expected 30000.
 > ```
 >
-> You will have to [unintsall Nix](https://zero-to-nix.com/start/uninstall/), and [intsall Nix](https://zero-to-nix.com/start/install/) again with `--nix-build-group-id 30000` flag.
+> You will have to [uninstall Nix](https://zero-to-nix.com/start/uninstall/), and [install Nix](https://zero-to-nix.com/start/install/) again with `--nix-build-group-id 30000` flag.
 
 ### 10. Make changes
 Finally, alter your system with this command:

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -11,7 +11,7 @@ let user = "dustin"; in
   ];
 
   # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
+  # services.nix-daemon.enable = true;
 
   # Setup user, packages, programs
   nix = {
@@ -25,7 +25,7 @@ let user = "dustin"; in
     };
 
     gc = {
-      user = "root";
+      # user = "root";
       automatic = true;
       interval = { Weekday = 0; Hour = 2; Minute = 0; };
       options = "--delete-older-than 30d";


### PR DESCRIPTION
There are 2 errors when running `nix run .#build` on macOS Sequoia.

1. The first one is the following:

  ```
  error: Build user group has mismatching GID, aborting activation
  The default Nix build user group ID was changed from 30000 to 350.
  You are currently managing Nix build users with nix-darwin, but your
  nixbld group has GID 350, whereas we expected 30000.

  Possible causes include setting up a new Nix installation with an
  existing nix-darwin configuration, setting up a new nix-darwin
  installation with an existing Nix installation, or manually increasing
  your `system.stateVersion` setting.

  You can set the configured group ID to match the actual value:

      ids.gids.nixbld = 350;

  We do not recommend trying to change the group ID with macOS user
  management tools without a complete uninstallation and reinstallation
  ```

  The fix has been mentioned in the README file.

2. The second one is the following:

```
error:
       … while evaluating the attribute 'value'
         at /nix/store/zbvf6xwri9kvf42xl3vai3mx8jry6ax8-source/lib/modules.nix:853:9:
          852|     in warnDeprecation opt //
          853|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          854|         inherit (res.defsFinal') highestPrio;

       … while evaluating the option `system.build':

       … while evaluating the attribute 'mergedValue'
         at /nix/store/zbvf6xwri9kvf42xl3vai3mx8jry6ax8-source/lib/modules.nix:888:5:
          887|     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
          888|     mergedValue =
             |     ^
          889|       if isDefined then

       … while evaluating definitions from `/nix/store/qp24528rxcnjskxsqs40aybaiqp7qq51-source/modules/system':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error:
       Failed assertions:
       - The option definition `nix.gc.user' in `/nix/store/zkkcgy73xlq8p4vk46jrxs0rm02aq8zx-source/hosts/darwin' no longer has any effect; please remove it.
       The garbage collection service now always runs as `root`.

       - The option definition `services.nix-daemon.enable' in `/nix/store/zkkcgy73xlq8p4vk46jrxs0rm02aq8zx-source/hosts/darwin' no longer has any effect; please remove it.
       nix-darwin now manages nix-daemon unconditionally when
       `nix.enable` is on.
```

After making the amendments as advised, the issue was resolved.