### PR TITLE
Remove warnings by fixing renamed options

### DIFF
--- a/templates/starter-with-secrets/hosts/nixos/default.nix
+++ b/templates/starter-with-secrets/hosts/nixos/default.nix
@@ -65,6 +65,7 @@ let user = "%USER%";
   };
 
   services = {
+    displayManager.defaultSession = "none+bspwm";
     xserver = {
       enable = true;
 
@@ -81,7 +82,6 @@ let user = "%USER%";
       # '';
 
       # LightDM Display Manager
-      displayManager.defaultSession = "none+bspwm";
       displayManager.lightdm = {
         enable = true;
         greeters.slick.enable = true;
@@ -93,13 +93,15 @@ let user = "%USER%";
         enable = true;
       };
 
-      # Turn Caps Lock into Ctrl
-      layout = "us";
-      xkbOptions = "ctrl:nocaps";
-
-      # Better support for general peripherals
-      libinput.enable = true;
+      xkb = {
+        # Turn Caps Lock into Ctrl
+        layout = "us";
+        options = "ctrl:nocaps";
+      }
     };
+
+    # Better support for general peripherals
+    libinput.enable = true;
 
     # Let's be able to SSH into this machine
     openssh.enable = true;
@@ -239,7 +241,7 @@ let user = "%USER%";
 
   # Video support
   hardware = {
-    opengl.enable = true;
+    graphics.enable = true;
     # nvidia.modesetting.enable = true;
 
     # Enable Xbox support

--- a/templates/starter/hosts/nixos/default.nix
+++ b/templates/starter/hosts/nixos/default.nix
@@ -64,6 +64,7 @@ let user = "%USER%";
   };
 
   services = { 
+    displayManager.defaultSession = "none+bspwm";
     xserver = {
       enable = true;
 
@@ -81,7 +82,6 @@ let user = "%USER%";
       # '';
 
       displayManager = {
-        defaultSession = "none+bspwm";
         lightdm = {
           enable = true;
           greeters.slick.enable = true;
@@ -94,14 +94,15 @@ let user = "%USER%";
         enable = true;
       };
 
-      # Turn Caps Lock into Ctrl
-      layout = "us";
-      xkbOptions = "ctrl:nocaps";
-
-      # Better support for general peripherals
-      libinput.enable = true;
-
+      xkb = {
+        # Turn Caps Lock into Ctrl
+        layout = "us";
+        options = "ctrl:nocaps";
+      }
     };
+
+    # Better support for general peripherals
+    libinput.enable = true;
 
     # Let's be able to SSH into this machine
     openssh.enable = true;
@@ -239,7 +240,7 @@ let user = "%USER%";
 
   # Video support
   hardware = {
-    opengl.enable = true;
+    graphics.enable = true;
     # pulseaudio.enable = true;
     # hardware.nvidia.modesetting.enable = true;
 


### PR DESCRIPTION
This commit fixes these warnings:

```
evaluation warning: The option `services.xserver.xkbOptions' defined in `/mnt/nix/store/ac8yy4g10vjb2q4mn861cgdgbkp8msg3-source/hosts/nixos' has been renamed to `services.xserver.xkb.options'.
evaluation warning: The option `services.xserver.layout' defined in `/mnt/nix/store/ac8yy4g10vjb2q4mn861cgdgbkp8msg3-source/hosts/nixos' has been renamed to `services.xserver.xkb.layout'.
evaluation warning: The option `services.xserver.libinput.enable' defined in `/mnt/nix/store/ac8yy4g10vjb2q4mn861cgdgbkp8msg3-source/hosts/nixos' has been renamed to `services.libinput.enable'.
evaluation warning: The option `services.xserver.displayManager.defaultSession' defined in `/mnt/nix/store/ac8yy4g10vjb2q4mn861cgdgbkp8msg3-source/hosts/nixos' has been renamed to `services.displayManager.defaultSession'.
evaluation warning: The option `hardware.opengl.enable' defined in `/mnt/nix/store/ac8yy4g10vjb2q4mn861cgdgbkp8msg3-source/hosts/nixos' has been renamed to `hardware.graphics.enable'.
```