### PR TITLE
Always use zsh to reset the Dock

### DIFF
--- a/modules/darwin/dock/default.nix
+++ b/modules/darwin/dock/default.nix
@@ -63,7 +63,7 @@ in
     {
       system.activationScripts.postActivation.text = ''
         echo >&2 "Setting up the Dock for ${cfg.username}..."
-        su ${cfg.username} -s /bin/sh <<'USERBLOCK'
+        sudo -u ${cfg.username} ${pkgs.zsh}/bin/zsh -s /bin/sh <<'USERBLOCK'
       haveURIs="$(${dockutil}/bin/dockutil --list | ${pkgs.coreutils}/bin/cut -f2)"
       if ! diff -wu <(echo -n "$haveURIs") <(echo -n '${wantURIs}') >&2 ; then
         echo >&2 "Resetting Dock."


### PR DESCRIPTION
I've switched my login shell to `fish` which does not support the `-s` option. 

Unfortunately Darwin's `su` does not allow overriding the shell while also passing parameters.