### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,4 +536,4 @@ I maintain this configuration in my spare time. I also build software for music 
 
 > "All we have to decide is what to do with the time that is given us." - J.R.R. Tolkien
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dustinlyons/nixos-config&type=Date)](https://star-history.com/#dustinlyons/nixos-config&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dustinlyons/nixos-config&type=Date)](https://star-history.dera.page/#dustinlyons/nixos-config&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken, so this fixes it. The previous provider is limited by GitHub stargazer API restrictions; this uses an alternative service that relies on a different data source and requires no API token, making the fix necessary to restore the chart.